### PR TITLE
Docs (readme): Fix GitHub badges to use new workflow badge routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![badge-build-github-workflows-img][]][badge-build-github-workflows-src] [![badge-version-dockerhub-image-badge][]][badge-image-dockerhub-tags-src] [![badge-size-dockerhub-image-badge][]][badge-image-dockerhub-tags-src]
 
-[badge-build-github-workflows-img]: https://img.shields.io/github/workflow/status/startersclan/docker-steamcmd/build/master?&label=build&logo=github&style=flat-square
+[badge-build-github-workflows-img]: https://img.shields.io/github/actions/workflow/status/startersclan/docker-steamcmd/build.yml?branch=master&label=&logo=github&style=flat-square
+
 [badge-build-github-workflows-src]: https://github.com/startersclan/docker-steamcmd/actions?query=branch%3Amaster
 [badge-image-dockerhub-src]: https://hub.docker.com/r/startersclan/steamcmd
 [badge-image-dockerhub-tags-src]: https://hub.docker.com/r/startersclan/steamcmd/tags


### PR DESCRIPTION
See https://github.com/badges/shields/issues/8671