### PR TITLE
Docs (readme): Fix GitHub badges to use new workflow badge routes (continued)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![badge-build-github-workflows-img][]][badge-build-github-workflows-src] [![badge-version-dockerhub-image-badge][]][badge-image-dockerhub-tags-src] [![badge-size-dockerhub-image-badge][]][badge-image-dockerhub-tags-src]
 
 [badge-build-github-workflows-img]: https://img.shields.io/github/actions/workflow/status/startersclan/docker-steamcmd/build.yml?branch=master&label=&logo=github&style=flat-square
-
 [badge-build-github-workflows-src]: https://github.com/startersclan/docker-steamcmd/actions?query=branch%3Amaster
 [badge-image-dockerhub-src]: https://hub.docker.com/r/startersclan/steamcmd
 [badge-image-dockerhub-tags-src]: https://hub.docker.com/r/startersclan/steamcmd/tags


### PR DESCRIPTION
Continuation of d49a446d36b556f8664e1677cf015148db4a054b