### PR TITLE
Feature: Bump `ubuntu` base image to `focal-20231003`

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         BASE_IMAGE_NAME: [ubuntu]
-        BASE_IMAGE_TAG: [xenial-20181005]
+        BASE_IMAGE_TAG: [focal-20231003]
         BUILD_IMAGE_VARIANT: [git, minimal]
         include:
-        - BASE_IMAGE_TAG: xenial-20181005
+        - BASE_IMAGE_TAG: focal-20231003
           BUILD_IMAGE_VARIANT: git
           TAG_LATEST: true
     env:

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@
 ## build variables ##
 # BASE_REGISTRY_NAMESPACE=library           # string - base image user or organization namespace - required
 # BASE_IMAGE_NAME=ubuntu                    # string - OS image namespace - required
-# BASE_IMAGE_TAG=xenial-20181005            # string - OS image tag - required
+# BASE_IMAGE_TAG=focal-20231003            # string - OS image tag - required
 # BUILD_REGISTRY_NAMESPACE=startersclan     # string - build image user or organization namespace - required
 # BUILD_IMAGE_NAME=steamcmd                 # string - build image namespace - required
 # BUILD_IMAGE_VARIANT=git                   # string - variant to build - required


### PR DESCRIPTION
Doing so adds support for `srcds/cs2` by circumventing the following error without breaking older games:

```
$ docker run --rm -it sourceservers/cs2 'game/bin/linuxsteamrt64/cs2 -dedicated +map de_dust2'
...
Launcher Error: FATAL: /server/game/bin/linuxsteamrt64/libtier0.so not loaded
        dlerror(): /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /server/game/bin/linuxsteamrt64/libtier0.so)
```